### PR TITLE
allow to list DRG that is managed in another compartment.

### DIFF
--- a/drg.tf
+++ b/drg.tf
@@ -13,7 +13,7 @@ resource "oci_core_drg" "drg" {
 }
 
 data "oci_core_drgs" "drg_data" {
-  compartment_id = var.compartment_id
+  compartment_id = coalesce(var.drg_compartment_id, var.compartment_id)
 
   filter {
     name   = "id"

--- a/variables.tf
+++ b/variables.tf
@@ -10,6 +10,12 @@ variable "compartment_id" {
   # no default value, asking user to explicitly set this variable's value. see codingconventions.adoc
 }
 
+variable "drg_compartment_id" {
+  description = "compartment id where the DRG is located"
+  type        = string
+  default     = null
+}
+
 variable "label_prefix" {
   description = "a string that will be prepended to all resources"
   type        = string


### PR DESCRIPTION
This PR relates to the issue #14.

This allow to use this module to make VCN attachments in terraform modules that are in different compartments than the DRG one.